### PR TITLE
Reworking room and member count tracking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,8 +48,6 @@ dependencies {
     implementation("org.xerial", "sqlite-jdbc", sqliteVersion)
     implementation("org.mariadb.jdbc", "mariadb-java-client", mariadbVersion)
 
-
-
     testImplementation(kotlin("test-junit5"))
     testImplementation("org.junit.jupiter", "junit-jupiter-api", junitVersion)
     testRuntimeOnly("org.junit.jupiter", "junit-jupiter-engine", junitVersion)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,11 @@ dependencies {
     val slf4jVersion = "2.0.0"
     val ktorVersion = "2.1.1"
 
+    val exposedVersion = "0.39.2"
+    val hikariVersion = "5.0.1"
+    val sqliteVersion = "3.39.2.1"
+    val mariadbVersion = "3.0.7"
+
     val junitVersion = "5.9.0"
 
     implementation("dev.kord", "kord-core", kordVersion)
@@ -32,6 +37,18 @@ dependencies {
     implementation("io.ktor", "ktor-server-cio", ktorVersion)
     implementation("io.ktor", "ktor-server-content-negotiation", ktorVersion)
     implementation("io.ktor", "ktor-serialization-kotlinx-json", ktorVersion)
+
+    implementation("org.jetbrains.exposed", "exposed-core", exposedVersion)
+    implementation("org.jetbrains.exposed", "exposed-dao", exposedVersion)
+    implementation("org.jetbrains.exposed", "exposed-jdbc", exposedVersion)
+    implementation("org.jetbrains.exposed", "exposed-kotlin-datetime", exposedVersion)
+
+    implementation("com.zaxxer", "HikariCP", hikariVersion)
+
+    implementation("org.xerial", "sqlite-jdbc", sqliteVersion)
+    implementation("org.mariadb.jdbc", "mariadb-java-client", mariadbVersion)
+
+
 
     testImplementation(kotlin("test-junit5"))
     testImplementation("org.junit.jupiter", "junit-jupiter-api", junitVersion)

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -685,3 +685,4 @@ style:
       - 'io.ktor.http.*'
       - 'io.ktor.serialization.*'
       - 'kotlinx.datetime.*'
+      - 'org.jetbrains.exposed.sql.*'

--- a/src/main/kotlin/de/gianttree/discord/w2g/Config.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/Config.kt
@@ -1,11 +1,16 @@
+@file:OptIn(ExperimentalTime::class)
+
 package de.gianttree.discord.w2g
 
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.File
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
 
 private val json = Json {
     encodeDefaults = true
@@ -18,7 +23,25 @@ data class Config(
     val debugMode: Boolean = false,
     val discordToken: String = "YOUR_DISCORD_TOKEN_HERE",
     val w2gToken: String = "YOUR_W2G_TOKEN_HERE",
-    val httpPort: Int = 12345
+    val httpPort: Int = 12345,
+    val intervals: Intervals = Intervals(),
+    val databaseConnection: DatabaseConnection = DatabaseConnection(),
+)
+
+@Serializable
+data class DatabaseConnection(
+    val jdbcUrl: String = "jdbc:mariadb://localhost:3306/w2g-bot",
+    val driver: String = "org.mariadb.jdbc.Driver",
+    val username: String = "w2g-bot",
+    val password: String = "w2g-bot",
+    val maxPoolSize: Int = 2,
+    val minIdle: Int = 1,
+)
+
+@Serializable
+data class Intervals(
+    val presenceInterval: DurationInSeconds = 5.minutes,
+    val guildMemberUpdateInterval: DurationInSeconds = 2.minutes,
 )
 
 @ExperimentalSerializationApi

--- a/src/main/kotlin/de/gianttree/discord/w2g/Context.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/Context.kt
@@ -5,6 +5,7 @@ import de.gianttree.discord.w2g.monitoring.RoomCounter
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import io.ktor.client.*
+import org.jetbrains.exposed.sql.Database
 import java.util.logging.Logger
 
 data class Context(
@@ -14,4 +15,5 @@ data class Context(
     val roomCounter: RoomCounter,
     val client: Kord,
     val httpClient: HttpClient,
+    val database: Database,
 )

--- a/src/main/kotlin/de/gianttree/discord/w2g/Context.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/Context.kt
@@ -1,8 +1,6 @@
 package de.gianttree.discord.w2g
 
-import de.gianttree.discord.w2g.monitoring.GuildMemberCount
 import de.gianttree.discord.w2g.monitoring.RoomCounter
-import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import io.ktor.client.*
 import org.jetbrains.exposed.sql.Database
@@ -11,7 +9,6 @@ import java.util.logging.Logger
 data class Context(
     val logger: Logger,
     val config: Config,
-    val guildMembers: MutableMap<Snowflake, GuildMemberCount>,
     val roomCounter: RoomCounter,
     val client: Kord,
     val httpClient: HttpClient,

--- a/src/main/kotlin/de/gianttree/discord/w2g/WatchTogether.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/WatchTogether.kt
@@ -182,7 +182,6 @@ private fun registerEvents(
                     logger.finest("Guild ${guild.name} (${guild.id}) has ${guild.approxMemberCount} members")
                     guild.lastUpdate = Clock.System.now().toEpochMilliseconds()
                 }
-//                delay(context.config.intervals.guildMemberUpdateInterval)
             }
         }
     }

--- a/src/main/kotlin/de/gianttree/discord/w2g/WatchTogether.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/WatchTogether.kt
@@ -117,7 +117,7 @@ suspend fun main() {
 
     val database = setupDatabaseConnection(config, logger)
 
-    val context = Context(logger, config, guildMembers, RoomCounter.load(), client, httpClient, database)
+    val context = Context(logger, config, guildMembers, RoomCounter(), client, httpClient, database)
 
     launchMonitoringServer(context)
 
@@ -164,7 +164,6 @@ private fun registerEvents(
             while (this.isActive && !context.config.debugMode) {
                 delay(context.config.intervals.presenceInterval)
                 context.client.updatePresence(context)
-                context.roomCounter.save()
             }
         }
         this.kord.launch {
@@ -229,7 +228,7 @@ private suspend fun ReactionAddEvent.handleTvReaction(context: Context) {
 
         message.addReaction(TV_REACTION)
 
-        context.roomCounter.addRoom()
+        context.roomCounter.addRoom(context, message.getGuildOrNull(), response.streamKey)
 
         logger.info(
             "Room ${response.streamKey} created for guild " +

--- a/src/main/kotlin/de/gianttree/discord/w2g/WatchTogether.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/WatchTogether.kt
@@ -2,6 +2,7 @@ package de.gianttree.discord.w2g
 
 import de.gianttree.discord.w2g.api.CreateRoom
 import de.gianttree.discord.w2g.api.UpdatePlaylist
+import de.gianttree.discord.w2g.database.setupDatabaseConnection
 import de.gianttree.discord.w2g.logging.W2GFormatter
 import de.gianttree.discord.w2g.monitoring.GuildMemberCount
 import de.gianttree.discord.w2g.monitoring.RoomCounter
@@ -114,7 +115,9 @@ suspend fun main() {
         }
     }
 
-    val context = Context(logger, config, guildMembers, RoomCounter.load(), client, httpClient)
+    val database = setupDatabaseConnection(config, logger)
+
+    val context = Context(logger, config, guildMembers, RoomCounter.load(), client, httpClient, database)
 
     launchMonitoringServer(context)
 

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/W2GDatabase.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/W2GDatabase.kt
@@ -3,15 +3,12 @@ package de.gianttree.discord.w2g.database
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import de.gianttree.discord.w2g.Config
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.DatabaseConfig
-import org.jetbrains.exposed.sql.SqlLogger
-import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.statements.StatementContext
 import org.jetbrains.exposed.sql.statements.expandArgs
 import java.util.logging.Logger
 
-fun setupDatabaseConnection(config: Config, logger: Logger): Database {
+suspend fun setupDatabaseConnection(config: Config, logger: Logger): Database {
     val hikariConfig = HikariConfig().apply {
         jdbcUrl = config.databaseConnection.jdbcUrl
         driverClassName = config.databaseConnection.driver
@@ -28,6 +25,11 @@ fun setupDatabaseConnection(config: Config, logger: Logger): Database {
             sqlLogger = W2GSQLLogger(logger)
         }
     })
+
+    suspendedInTransaction(database) {
+        SchemaUtils.createMissingTablesAndColumns(Guilds, Rooms)
+    }
+
     return database
 }
 

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/W2GDatabase.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/W2GDatabase.kt
@@ -1,0 +1,38 @@
+package de.gianttree.discord.w2g.database
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import de.gianttree.discord.w2g.Config
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.DatabaseConfig
+import org.jetbrains.exposed.sql.SqlLogger
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.statements.StatementContext
+import org.jetbrains.exposed.sql.statements.expandArgs
+import java.util.logging.Logger
+
+fun setupDatabaseConnection(config: Config, logger: Logger): Database {
+    val hikariConfig = HikariConfig().apply {
+        jdbcUrl = config.databaseConnection.jdbcUrl
+        driverClassName = config.databaseConnection.driver
+        username = config.databaseConnection.username
+        password = config.databaseConnection.password
+        minimumIdle = config.databaseConnection.minIdle
+        maximumPoolSize = config.databaseConnection.maxPoolSize
+    }
+
+    val hikariDatasource = HikariDataSource(hikariConfig)
+
+    val database = Database.connect(hikariDatasource, databaseConfig = DatabaseConfig {
+        if (config.debugMode) {
+            sqlLogger = W2GSQLLogger(logger)
+        }
+    })
+    return database
+}
+
+class W2GSQLLogger(private val logger: Logger) : SqlLogger {
+    override fun log(context: StatementContext, transaction: Transaction) {
+        logger.finest("SQL: " + context.expandArgs(transaction))
+    }
+}

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/W2GDatabase.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/W2GDatabase.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.statements.StatementContext
 import org.jetbrains.exposed.sql.statements.expandArgs
 import java.util.logging.Logger
+import kotlin.time.Duration.Companion.seconds
 
 suspend fun setupDatabaseConnection(config: Config, logger: Logger): Database {
     val hikariConfig = HikariConfig().apply {
@@ -16,6 +17,7 @@ suspend fun setupDatabaseConnection(config: Config, logger: Logger): Database {
         password = config.databaseConnection.password
         minimumIdle = config.databaseConnection.minIdle
         maximumPoolSize = config.databaseConnection.maxPoolSize
+        leakDetectionThreshold = 5.seconds.inWholeMilliseconds
     }
 
     val hikariDatasource = HikariDataSource(hikariConfig)

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.Snowflake
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.kotlin.datetime.CurrentTimestamp
 import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+import dev.kord.core.entity.Guild as KordGuild
 
 object Guilds : SnowflakeIdTable() {
     val name = varchar("name", 100).index()
@@ -18,7 +19,14 @@ class Guild(id: EntityID<Snowflake>) : SnowflakeEntity(id) {
 
     val rooms by Room referrersOn Rooms.guild
 
-    companion object : SnowflakeEntityClass<Guild>(Guilds)
+    companion object : SnowflakeEntityClass<Guild>(Guilds) {
+        fun getOrCreate(kordGuild: KordGuild): Guild {
+            return findById(kordGuild.id) ?: new(kordGuild.id) {}.apply {
+                this.name = kordGuild.name
+                this.approxMemberCount = kordGuild.approximateMemberCount ?: 0
+            }
+        }
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
@@ -1,0 +1,45 @@
+package de.gianttree.discord.w2g.database
+
+import dev.kord.common.entity.Snowflake
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.kotlin.datetime.CurrentTimestamp
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+
+object Guilds : SnowflakeIdTable() {
+    val name = varchar("name", 100).index()
+    val approxMemberCount = integer("approx_member_count")
+    val lastUpdate = timestamp("last_update").defaultExpression(CurrentTimestamp()).index()
+}
+
+class Guild(id: EntityID<Snowflake>) : SnowflakeEntity(id) {
+    var name by Guilds.name
+    var approxMemberCount by Guilds.approxMemberCount
+    var lastUpdate by Guilds.lastUpdate
+
+    val rooms by Room referrersOn Rooms.guild
+
+    companion object : SnowflakeEntityClass<Guild>(Guilds)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Guild) return false
+
+        if (name != other.name) return false
+        if (approxMemberCount != other.approxMemberCount) return false
+        if (lastUpdate != other.lastUpdate) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + approxMemberCount
+        result = 31 * result + lastUpdate.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "Guild(name='$name', approxMemberCount=$approxMemberCount, lastUpdate=$lastUpdate)"
+    }
+
+}

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
@@ -9,8 +9,11 @@ import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.sum
 import dev.kord.core.entity.Guild as KordGuild
 
+
+const val MAX_GUILD_NAME_LENGTH = 100
+
 object Guilds : SnowflakeIdTable() {
-    val name = varchar("name", 100).index()
+    val name = varchar("name", MAX_GUILD_NAME_LENGTH).index()
     val approxMemberCount = integer("approx_member_count")
     val lastUpdate = long("last_update").clientDefault { Clock.System.now().toEpochMilliseconds() }.index()
     val active = bool("active").default(true).index()
@@ -81,7 +84,13 @@ class Guild(id: EntityID<Snowflake>) : SnowflakeEntity(id) {
     }
 
     override fun toString(): String {
-        return "Guild(name='$name', approxMemberCount=$approxMemberCount, lastUpdate=$lastUpdate, active=$active, rooms=$rooms)"
+        return "Guild(" +
+                "name='$name', " +
+                "approxMemberCount=$approxMemberCount, " +
+                "lastUpdate=$lastUpdate, " +
+                "active=$active, " +
+                "rooms=$rooms" +
+                ")"
     }
 
 }

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
@@ -1,9 +1,9 @@
 package de.gianttree.discord.w2g.database
 
 import dev.kord.common.entity.Snowflake
+import kotlinx.datetime.Clock
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.kotlin.datetime.CurrentTimestamp
 import org.jetbrains.exposed.sql.min
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.sum
@@ -12,7 +12,7 @@ import dev.kord.core.entity.Guild as KordGuild
 object Guilds : SnowflakeIdTable() {
     val name = varchar("name", 100).index()
     val approxMemberCount = integer("approx_member_count")
-    val lastUpdate = long("last_update").defaultExpression(CurrentTimestamp()).index()
+    val lastUpdate = long("last_update").clientDefault { Clock.System.now().toEpochMilliseconds() }.index()
     val active = bool("active").default(true).index()
 
     fun getMemberCountSum(): Int {

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
@@ -37,6 +37,10 @@ object Guilds : SnowflakeIdTable() {
 
         return Guild.wrapRow(resultSet)
     }
+
+    fun getActiveCount(): Int {
+        return Guilds.select { active eq true }.count().toInt()
+    }
 }
 
 class Guild(id: EntityID<Snowflake>) : SnowflakeEntity(id) {

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/guild.kt
@@ -32,11 +32,10 @@ object Guilds : SnowflakeIdTable() {
         // SELECT MIN(last_update) FROM guilds WHERE active = true
         val minSelect = Guilds.slice(minGroup)
             .select { active eq true }
-            .map { it[minGroup] }.single()
-            ?: return null
 
         // SELECT * FROM guilds WHERE last_update = minSelect AND active = true
-        val resultSet = Guilds.select { (lastUpdate eq minSelect) and (active eq true) }.firstOrNull() ?: return null
+        val resultSet =
+            Guilds.select { (lastUpdate eqSubQuery minSelect) and (active eq true) }.firstOrNull() ?: return null
 
         return Guild.wrapRow(resultSet)
     }

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
@@ -6,10 +6,12 @@ import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
 
+const val MAX_ROOM_ID_LENGTH = 255
+
 object Rooms : IntIdTable() {
     val guild = reference("guild", Guilds).index()
     val createdAt = long("created_at").clientDefault { Clock.System.now().toEpochMilliseconds() }.index()
-    val w2gId = varchar("w2g_id", 255)
+    val w2gId = varchar("w2g_id", MAX_ROOM_ID_LENGTH)
 }
 
 class Room(id: EntityID<Int>) : IntEntity(id) {

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
@@ -26,6 +26,7 @@ class Room(id: EntityID<Int>) : IntEntity(id) {
 
         if (guild != other.guild) return false
         if (createdAt != other.createdAt) return false
+        if (w2gId != other.w2gId) return false
 
         return true
     }
@@ -33,10 +34,11 @@ class Room(id: EntityID<Int>) : IntEntity(id) {
     override fun hashCode(): Int {
         var result = guild.hashCode()
         result = 31 * result + createdAt.hashCode()
+        result = 31 * result + w2gId.hashCode()
         return result
     }
 
     override fun toString(): String {
-        return "Room(guild=$guild, createdAt=$createdAt)"
+        return "Room(guild=$guild, createdAt=$createdAt, w2gId='$w2gId')"
     }
 }

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
@@ -1,0 +1,40 @@
+package de.gianttree.discord.w2g.database
+
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.kotlin.datetime.CurrentTimestamp
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+
+object Rooms : IntIdTable() {
+    val guild = reference("guild", Guilds).index()
+    val createdAt = timestamp("created_at").defaultExpression(CurrentTimestamp()).index()
+}
+
+class Room(id: EntityID<Int>) : IntEntity(id) {
+    companion object : IntEntityClass<Room>(Rooms)
+
+    var guild by Guild referencedOn Rooms.guild
+    var createdAt by Rooms.createdAt
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Room) return false
+
+        if (guild != other.guild) return false
+        if (createdAt != other.createdAt) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = guild.hashCode()
+        result = 31 * result + createdAt.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "Room(guild=$guild, createdAt=$createdAt)"
+    }
+}

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
@@ -9,7 +9,7 @@ import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 
 object Rooms : IntIdTable() {
     val guild = reference("guild", Guilds).index()
-    val createdAt = timestamp("created_at").defaultExpression(CurrentTimestamp()).index()
+    val createdAt = long("created_at").defaultExpression(CurrentTimestamp()).index()
     val w2gId = varchar("w2g_id", 255)
 }
 

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
@@ -10,6 +10,7 @@ import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 object Rooms : IntIdTable() {
     val guild = reference("guild", Guilds).index()
     val createdAt = timestamp("created_at").defaultExpression(CurrentTimestamp()).index()
+    val w2gId = varchar("w2g_id", 255)
 }
 
 class Room(id: EntityID<Int>) : IntEntity(id) {
@@ -17,6 +18,7 @@ class Room(id: EntityID<Int>) : IntEntity(id) {
 
     var guild by Guild referencedOn Rooms.guild
     var createdAt by Rooms.createdAt
+    var w2gId by Rooms.w2gId
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/room.kt
@@ -1,15 +1,14 @@
 package de.gianttree.discord.w2g.database
 
+import kotlinx.datetime.Clock
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
-import org.jetbrains.exposed.sql.kotlin.datetime.CurrentTimestamp
-import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 
 object Rooms : IntIdTable() {
     val guild = reference("guild", Guilds).index()
-    val createdAt = long("created_at").defaultExpression(CurrentTimestamp()).index()
+    val createdAt = long("created_at").clientDefault { Clock.System.now().toEpochMilliseconds() }.index()
     val w2gId = varchar("w2g_id", 255)
 }
 

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/snowflake.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/snowflake.kt
@@ -1,0 +1,42 @@
+package de.gianttree.discord.w2g.database
+
+import dev.kord.common.entity.Snowflake
+import org.jetbrains.exposed.dao.Entity
+import org.jetbrains.exposed.dao.EntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ColumnType
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.vendors.currentDialect
+
+open class SnowflakeIdTable : IdTable<Snowflake>() {
+    override val id = snowflake("id").entityId()
+
+    override val primaryKey by lazy { super.primaryKey ?: PrimaryKey(id) }
+}
+
+open class SnowflakeEntity(id: EntityID<Snowflake>) : Entity<Snowflake>(id)
+
+open class SnowflakeEntityClass<out E : SnowflakeEntity>(table: SnowflakeIdTable, entityType: Class<E>? = null) :
+    EntityClass<Snowflake, E>(table, entityType)
+
+fun Table.snowflake(name: String): Column<Snowflake> = registerColumn(name, SnowflakeColumnType())
+
+class SnowflakeColumnType : ColumnType() {
+    override fun sqlType(): String = currentDialect.dataTypeProvider.longType()
+
+    override fun valueFromDB(value: Any): Snowflake {
+        return when (value) {
+            is Snowflake -> value
+            is Number -> Snowflake(value.toLong())
+            is String -> Snowflake(value.toLong())
+            else -> error("Unexpected value of type Snowflake: $value of ${value::class.qualifiedName}")
+        }
+    }
+
+    override fun notNullValueToDB(value: Any): Any {
+        val v = if (value is Snowflake) value.value.toLong() else value
+        return super.notNullValueToDB(v)
+    }
+}

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/transaction.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/transaction.kt
@@ -14,11 +14,11 @@ import org.jetbrains.exposed.sql.transactions.experimental.suspendedTransaction
  * be created.
  */
 suspend fun <T> suspendedInTransaction(
-    database: Database? = null,
+    database: Database,
     statement: suspend Transaction.() -> T
 ): T {
     val transaction = TransactionManager.currentOrNull()
-    return if (transaction != null && (database == null || transaction.db == database)) {
+    return if (transaction != null && (transaction.db == database)) {
         transaction.suspendedTransaction(null, statement)
     } else {
         newSuspendedTransaction(null, database, statement = statement)

--- a/src/main/kotlin/de/gianttree/discord/w2g/database/transaction.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/database/transaction.kt
@@ -1,0 +1,26 @@
+package de.gianttree.discord.w2g.database
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.transactions.experimental.suspendedTransaction
+
+/**
+ * Executes the given suspending [statement] in the current transaction.
+ * If there is no current transaction, a new one will be created.
+ *
+ * If the databases of the transactions differ, a new nested transaction will
+ * be created.
+ */
+suspend fun <T> suspendedInTransaction(
+    database: Database? = null,
+    statement: suspend Transaction.() -> T
+): T {
+    val transaction = TransactionManager.currentOrNull()
+    return if (transaction != null && (database == null || transaction.db == database)) {
+        transaction.suspendedTransaction(null, statement)
+    } else {
+        newSuspendedTransaction(null, database, statement = statement)
+    }
+}

--- a/src/main/kotlin/de/gianttree/discord/w2g/monitoring/RoomCounter.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/monitoring/RoomCounter.kt
@@ -1,28 +1,20 @@
 package de.gianttree.discord.w2g.monitoring
 
-import java.io.File
+import de.gianttree.discord.w2g.Context
+import de.gianttree.discord.w2g.database.Guild
+import de.gianttree.discord.w2g.database.Room
+import de.gianttree.discord.w2g.database.suspendedInTransaction
+import dev.kord.core.entity.Guild as KordGuild
 
-private const val ROOM_COUNTER_FILENAME = "roomcounter.txt"
+class RoomCounter() {
 
-class RoomCounter(rooms: Int = 0) {
-    var rooms: Int = rooms
-        private set
-
-    fun addRoom() {
-        rooms++
-    }
-
-    fun save() {
-        File(ROOM_COUNTER_FILENAME).writeText(rooms.toString())
-    }
-
-    companion object {
-        fun load(): RoomCounter {
-            val fileContent = File(ROOM_COUNTER_FILENAME).takeIf { it.isFile }?.readText() ?: "0"
-            return if (fileContent.matches(Regex("[0-9]+"))) {
-                RoomCounter(fileContent.toInt())
-            } else {
-                RoomCounter()
+    suspend fun addRoom(context: Context, kordGuild: KordGuild?, w2gId: String) {
+        if (kordGuild == null) return
+        suspendedInTransaction(context.database) {
+            val guild = Guild.getOrCreate(kordGuild)
+            Room.new {
+                this.guild = guild
+                this.w2gId = w2gId
             }
         }
     }

--- a/src/main/kotlin/de/gianttree/discord/w2g/monitoring/RoomCounter.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/monitoring/RoomCounter.kt
@@ -6,7 +6,7 @@ import de.gianttree.discord.w2g.database.Room
 import de.gianttree.discord.w2g.database.suspendedInTransaction
 import dev.kord.core.entity.Guild as KordGuild
 
-class RoomCounter() {
+class RoomCounter {
 
     suspend fun addRoom(context: Context, kordGuild: KordGuild?, w2gId: String) {
         if (kordGuild == null) return

--- a/src/main/kotlin/de/gianttree/discord/w2g/monitoring/server.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/monitoring/server.kt
@@ -1,7 +1,6 @@
 package de.gianttree.discord.w2g.monitoring
 
 import de.gianttree.discord.w2g.Context
-import de.gianttree.discord.w2g.database.Guild
 import de.gianttree.discord.w2g.database.Guilds
 import de.gianttree.discord.w2g.database.Room
 import de.gianttree.discord.w2g.database.suspendedInTransaction
@@ -14,7 +13,6 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.datetime.*
 import kotlinx.serialization.Serializable
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import java.lang.management.ManagementFactory
 import kotlin.time.ExperimentalTime
 
@@ -41,7 +39,7 @@ fun launchMonitoringServer(context: Context): CIOApplicationEngine {
                             context.client.resources.shards.totalShards,
                             context.client.gateway.gateways.size,
                             context.client.gateway.gateways.mapValues { it.value.ping.value?.toDateTimePeriod() },
-                            Guild.count(Guilds.active eq true).toInt(),
+                            Guilds.getActiveCount(),
                             Guilds.getMemberCountSum(),
                             Room.count()
                         )

--- a/src/main/kotlin/de/gianttree/discord/w2g/monitoring/server.kt
+++ b/src/main/kotlin/de/gianttree/discord/w2g/monitoring/server.kt
@@ -1,6 +1,8 @@
 package de.gianttree.discord.w2g.monitoring
 
 import de.gianttree.discord.w2g.Context
+import de.gianttree.discord.w2g.database.Room
+import de.gianttree.discord.w2g.database.suspendedInTransaction
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.cio.*
@@ -37,7 +39,7 @@ fun launchMonitoringServer(context: Context): CIOApplicationEngine {
                         context.client.gateway.gateways.mapValues { it.value.ping.value?.toDateTimePeriod() },
                         context.client.guilds.count(),
                         context.guildMembers.values.sumOf(GuildMemberCount::memberCount),
-                        context.roomCounter.rooms
+                        suspendedInTransaction { Room.count() }
                     )
                 )
             }
@@ -55,5 +57,5 @@ data class Status(
     val pings: Map<Int, DateTimePeriod?>,
     val numGuilds: Int,
     val approxMemberCount: Int,
-    val roomCount: Int,
+    val roomCount: Long,
 )

--- a/src/test/kotlin/GuildQueryTest.kt
+++ b/src/test/kotlin/GuildQueryTest.kt
@@ -1,0 +1,43 @@
+package de.gianttree.discord.w2g
+
+import de.gianttree.discord.w2g.database.Guilds
+import de.gianttree.discord.w2g.database.setupDatabaseConnection
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.logging.Logger
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GuildQueryTest {
+
+    lateinit var database: Database
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @BeforeAll
+    fun setupDatabase() {
+        val config = readConfig()
+        runBlocking {
+            this@GuildQueryTest.database = setupDatabaseConnection(config, Logger.getAnonymousLogger())
+        }
+    }
+
+    @Test
+    fun testLeastRecentUpdate() {
+        transaction(this.database) {
+            assertNotNull(Guilds.getGuildLeastRecentUpdate())
+        }
+    }
+
+    @Test
+    fun testGetActiveCount() {
+        transaction(this.database) {
+            assertTrue(Guilds.getActiveCount() > 0)
+        }
+    }
+}

--- a/src/test/kotlin/GuildQueryTest.kt
+++ b/src/test/kotlin/GuildQueryTest.kt
@@ -1,10 +1,15 @@
 package de.gianttree.discord.w2g
 
+import de.gianttree.discord.w2g.database.Guild
 import de.gianttree.discord.w2g.database.Guilds
 import de.gianttree.discord.w2g.database.setupDatabaseConnection
+import de.gianttree.discord.w2g.database.suspendedInTransaction
+import dev.kord.common.entity.Snowflake
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
 import kotlinx.serialization.ExperimentalSerializationApi
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -24,6 +29,15 @@ class GuildQueryTest {
         val config = readConfig()
         runBlocking {
             this@GuildQueryTest.database = setupDatabaseConnection(config, Logger.getAnonymousLogger())
+            suspendedInTransaction(this@GuildQueryTest.database) {
+                Guilds.deleteAll()
+                Guild.new(Snowflake(0)) {
+                    this.name = "Test Guild"
+                    this.active = true
+                    this.approxMemberCount = 0
+                    this.lastUpdate = Clock.System.now().toEpochMilliseconds()
+                }
+            }
         }
     }
 

--- a/src/test/kotlin/GuildQueryTest.kt
+++ b/src/test/kotlin/GuildQueryTest.kt
@@ -26,7 +26,6 @@ class GuildQueryTest {
     @OptIn(ExperimentalSerializationApi::class)
     @BeforeAll
     fun setupDatabase() {
-        val config = readConfig()
         runBlocking {
             this@GuildQueryTest.database = setupDatabaseConnection(config, Logger.getAnonymousLogger())
             suspendedInTransaction(this@GuildQueryTest.database) {
@@ -53,5 +52,16 @@ class GuildQueryTest {
         transaction(this.database) {
             assertTrue(Guilds.getActiveCount() > 0)
         }
+    }
+
+    companion object {
+        val config = Config(
+            databaseConnection = DatabaseConnection(
+                jdbcUrl = "jdbc:sqlite:mem:test",
+                driver = "org.sqlite.JDBC",
+                maxPoolSize = 1,
+                minIdle = 1,
+            )
+        )
     }
 }

--- a/src/test/kotlin/database/GuildQueryTest.kt
+++ b/src/test/kotlin/database/GuildQueryTest.kt
@@ -1,13 +1,8 @@
-package de.gianttree.discord.w2g
+package de.gianttree.discord.w2g.database
 
-import de.gianttree.discord.w2g.database.Guild
-import de.gianttree.discord.w2g.database.Guilds
-import de.gianttree.discord.w2g.database.setupDatabaseConnection
-import de.gianttree.discord.w2g.database.suspendedInTransaction
 import dev.kord.common.entity.Snowflake
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
-import kotlinx.serialization.ExperimentalSerializationApi
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -21,9 +16,8 @@ import kotlin.test.assertTrue
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GuildQueryTest {
 
-    lateinit var database: Database
+    private lateinit var database: Database
 
-    @OptIn(ExperimentalSerializationApi::class)
     @BeforeAll
     fun setupDatabase() {
         runBlocking {
@@ -52,16 +46,5 @@ class GuildQueryTest {
         transaction(this.database) {
             assertTrue(Guilds.getActiveCount() > 0)
         }
-    }
-
-    companion object {
-        val config = Config(
-            databaseConnection = DatabaseConnection(
-                jdbcUrl = "jdbc:sqlite:mem:test",
-                driver = "org.sqlite.JDBC",
-                maxPoolSize = 1,
-                minIdle = 1,
-            )
-        )
     }
 }

--- a/src/test/kotlin/database/RoomQueryTest.kt
+++ b/src/test/kotlin/database/RoomQueryTest.kt
@@ -1,0 +1,51 @@
+package de.gianttree.discord.w2g.database
+
+import dev.kord.common.entity.Snowflake
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.deleteAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
+import java.util.logging.Logger
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RoomQueryTest {
+
+    private lateinit var guild: Guild
+    private lateinit var database: Database
+
+    @BeforeAll
+    fun setupDatabase() {
+        runBlocking {
+            this@RoomQueryTest.database = setupDatabaseConnection(config, Logger.getAnonymousLogger())
+            suspendedInTransaction(this@RoomQueryTest.database) {
+                Guilds.deleteAll()
+                this@RoomQueryTest.guild = Guild.new(Snowflake(0)) {
+                    this.name = "Test Guild"
+                    this.active = true
+                    this.approxMemberCount = 0
+                    this.lastUpdate = Clock.System.now().toEpochMilliseconds()
+                }
+                Rooms.deleteAll()
+            }
+        }
+    }
+
+    @Test
+    fun createRoom() {
+        assertDoesNotThrow {
+            transaction {
+                Room.new {
+                    this.guild = this@RoomQueryTest.guild
+                    this.w2gId = "123456789"
+                    this.createdAt = Clock.System.now().toEpochMilliseconds()
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/kotlin/database/common.kt
+++ b/src/test/kotlin/database/common.kt
@@ -1,0 +1,13 @@
+package de.gianttree.discord.w2g.database
+
+import de.gianttree.discord.w2g.Config
+import de.gianttree.discord.w2g.DatabaseConnection
+
+val config = Config(
+    databaseConnection = DatabaseConnection(
+        jdbcUrl = "jdbc:sqlite:mem:test",
+        driver = "org.sqlite.JDBC",
+        maxPoolSize = 1,
+        minIdle = 1,
+    )
+)


### PR DESCRIPTION
This PR reworks a few internal functions that track created rooms and guild member counts.  
The original functionality of the bot is not influenced by these changes.

Most notably the way created W2G.TV rooms are tracked has been changed and expanded.
Rooms are now properly tracked in a database with their creation timestamp. This allows proper time-slicing for monitoring and expansion preparations. Additionally, the guild ids are stored in preparation of sharding such that high traffic guilds can be isolated to separate shards, reducing singular shard load.

Guild member count tracking has also been integrated into the database.
This allows multiple shards to work together in updating guilds and centralizes the former process-bound storage of member counts.